### PR TITLE
Changes placement location of rendered math node.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "figma-plugin-react-template",
+	"name": "figma-LaTeX-complete",
 	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
@@ -843,9 +843,9 @@
 			"dev": true
 		},
 		"cacache": {
-			"version": "12.0.3",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-			"integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+			"version": "12.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+			"integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
 			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.5",
@@ -2115,9 +2115,9 @@
 			}
 		},
 		"figgy-pudding": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+			"integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
 			"dev": true
 		},
 		"figures": {
@@ -4412,20 +4412,12 @@
 			"integrity": "sha512-OHlnKQqfFPEYZGdz2JWL0obrr82vVilha0WCUZslYfN+v+oz4VpmERnoHdTUWvOUVHNYjFkpOYnLEeHnt1BdsQ=="
 		},
 		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
-				}
+				"minimist": "^1.2.5"
 			}
 		},
 		"move-concurrently": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "description": "Figma plugin to render LaTeX",
     "license": "ISC",
     "scripts": {
-        "build": "/usr/local/bin/node node_modules/.bin/webpack --mode=production",
-        "build:watch": "/usr/local/bin/node node_modules/.bin/webpack --mode=development --watch",
+        "build": "webpack",
+        "build:watch": "webpack --mode=development --watch",
         "prettier:format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,json}' "
     },
     "dependencies": {

--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -6,9 +6,11 @@ figma.ui.onmessage = msg => {
         const svg = node.children[0];
         svg.resize(msg.scale, svg.height * (msg.scale / svg.width));
         svg.name = msg.source;
+        const {x, y} = figma.viewport.center;
+        svg.x = x;
+        svg.y = y;
         figma.currentPage.appendChild(svg);
         figma.currentPage.selection = [svg];
-        figma.viewport.scrollAndZoomIntoView([svg]);
         node.remove();
     }
 


### PR DESCRIPTION
## Problem
The plugin places the output node in the center of the document, this is great for small projects where most nodes are located around that area. However, for large projects where nodes are scattered around through the canvas it leads to very awkward workflows where you have to zoom out and manually carry the node back to its intended position.

## Fix
This PR,
- Places the output node in the center of the viewport instead of the center of the document, and removes the automatic scroll and zoom action. I think this leads to a more ergonomic and faster workflow as you no longer have to drag the svg across your screen.
- Changes the `package.json` file to use the local development version of webpack instead of the global version.