### PR TITLE
Added plugin window resizing function

### DIFF
--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -16,6 +16,8 @@ import '../styles/ui.css';
 import symbols from '../../symbols.json';
 import {Range} from 'ace-builds';
 
+import Corner from './Corner';
+
 declare function require(path: string): any;
 
 const App = ({}) => {
@@ -93,8 +95,9 @@ const App = ({}) => {
                 onChange={onChange}
                 value={code}
                 width="100%"
-                height="65px"
+                height="calc(55% - 25px)"
                 showGutter={false}
+                showPrintMargin={false}
                 focus={true}
                 wrapEnabled={true}
                 onLoad={onLoad}
@@ -104,7 +107,7 @@ const App = ({}) => {
             />
             <div
                 style={{
-                    height: '75px',
+                    height: 'calc(45% - 25px)',
                     width: '100%',
                     border: '1px solid gray',
                     display: 'flex',
@@ -114,12 +117,13 @@ const App = ({}) => {
                 }}
                 dangerouslySetInnerHTML={{__html: preview}}
             />
-            <div style={{paddingTop: '10px'}}>
+            <div style={{paddingTop: '10px', height: '50px'}}>
                 <button className="primary" onClick={onCreate}>
                     Create
                 </button>
                 <button onClick={onCancel}>Cancel</button>
             </div>
+            <Corner />
         </div>
     );
 };

--- a/src/app/components/Corner.tsx
+++ b/src/app/components/Corner.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+
+const Corner = ({}) => {
+    const resizeIcon = React.useRef<SVGSVGElement>(undefined);
+
+    const resizeWindow = e => {
+        const size = {
+            w: Math.max(50, Math.floor(e.clientX + 5)),
+            h: Math.max(50, Math.floor(e.clientY + 5)),
+        };
+        parent.postMessage({pluginMessage: {type: 'resize', size: size}}, '*');
+    };
+
+    React.useEffect(() => {
+        resizeIcon.current.onpointerdown = e => {
+            resizeIcon.current.onpointermove = resizeWindow;
+            resizeIcon.current.setPointerCapture(e.pointerId);
+        };
+        resizeIcon.current.onpointerup = e => {
+            resizeIcon.current.onpointermove = null;
+            resizeIcon.current.releasePointerCapture(e.pointerId);
+        };
+    });
+
+    return (
+        <div>
+            <svg
+                ref={resizeIcon}
+                id="corner"
+                style={{position: 'absolute', right: '1px', bottom: '2px', cursor: 'nwse-resize'}}
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <path d="M16 0V16H0L16 0Z" fill="white" />
+                <path d="M6.22577 16H3L16 3V6.22576L6.22577 16Z" fill="#8C8C8C" />
+                <path d="M11.8602 16H8.63441L16 8.63441V11.8602L11.8602 16Z" fill="#8C8C8C" />
+            </svg>
+        </div>
+    );
+};
+
+export default Corner;

--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -1,5 +1,9 @@
 figma.showUI(__html__);
 
+figma.clientStorage.getAsync('size').then(size => {
+    if (size) figma.ui.resize(size.w, size.h);
+});
+
 const postSourceCode = () => {
     const selection = figma.currentPage.selection;
     if (selection.length !== 0) {
@@ -10,34 +14,42 @@ const postSourceCode = () => {
 postSourceCode();
 
 figma.ui.onmessage = msg => {
-    if (msg.type === 'create-latex-svg') {
-        const node = figma.createNodeFromSvg(msg.svg);
-        if (node.children.length !== 0) {
-            const svg = <GroupNode>node.children[0];
-            const selection = figma.currentPage.selection;
-            (svg as any).setRelaunchData({edit: ''});
-            svg.resize(msg.scale, svg.height * (msg.scale / svg.width));
-            if (selection.length !== 0 && selection[0].getPluginData('source') != '') {
-                const groupNode = <GroupNode>selection[0];
-                groupNode.setPluginData('source', msg.source);
-                groupNode.name = msg.source;
-                svg.x = groupNode.x;
-                svg.y = groupNode.y;
-                groupNode.appendChild(svg.children[0]);
-                groupNode.children[0].remove();
-                figma.currentPage.selection = [groupNode];
-            } else {
-                svg.setPluginData('source', msg.source);
-                svg.name = msg.source;
-                const {x, y} = figma.viewport.center;
-                svg.x = x;
-                svg.y = y;
-                figma.currentPage.appendChild(svg);
-                figma.currentPage.selection = [svg];
+    switch (msg.type) {
+        case 'create-latex-svg':
+            const node = figma.createNodeFromSvg(msg.svg);
+            if (node.children.length !== 0) {
+                const svg = <GroupNode>node.children[0];
+                const selection = figma.currentPage.selection;
+                (svg as any).setRelaunchData({edit: ''});
+                svg.resize(msg.scale, svg.height * (msg.scale / svg.width));
+                if (selection.length !== 0 && selection[0].getPluginData('source') != '') {
+                    const groupNode = <GroupNode>selection[0];
+                    groupNode.setPluginData('source', msg.source);
+                    groupNode.name = msg.source;
+                    svg.x = groupNode.x;
+                    svg.y = groupNode.y;
+                    groupNode.appendChild(svg.children[0]);
+                    groupNode.children[0].remove();
+                    figma.currentPage.selection = [groupNode];
+                } else {
+                    svg.setPluginData('source', msg.source);
+                    svg.name = msg.source;
+                    const {x, y} = figma.viewport.center;
+                    svg.x = x;
+                    svg.y = y;
+                    figma.currentPage.appendChild(svg);
+                    figma.currentPage.selection = [svg];
+                }
             }
-        }
-        node.remove();
+            node.remove();
+            figma.closePlugin();
+            break;
+        case 'resize':
+            figma.ui.resize(msg.size.w, msg.size.h);
+            figma.clientStorage.setAsync('size', msg.size);
+            break;
+        case 'cancel':
+            figma.closePlugin();
+            break;
     }
-
-    figma.closePlugin();
 };


### PR DESCRIPTION
I have created a React component called Corner that adds the ability to resize the plugin window. The screen height and width are stored in the clientStorage of figma, and the next time the plugin is launched, the stored values are referenced.

For more information about figma.clientStorage, we referred to the official Figma API.
https://www.figma.com/plugin-docs/api/figma-clientStorage/

Mainly, the code was referenced from
https://gist.github.com/sonnylazuardi/e55300f28fbe109db052f6568fee5a04